### PR TITLE
Remove app volume instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ RUN sh $BITNAMI_PREFIX/install.sh
 COPY rootfs/ /
 
 EXPOSE 80 443
-VOLUME ["$BITNAMI_APP_VOL_PREFIX/conf", "$BITNAMI_APP_VOL_PREFIX/logs", "/app"]
+VOLUME ["$BITNAMI_APP_VOL_PREFIX/conf", "$BITNAMI_APP_VOL_PREFIX/logs"]
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -338,6 +338,12 @@ using the `bats` command.
 bats test.sh
 ```
 
+# Changelog
+
+## development (2015-10-05)
+
+- `/app` directory is no longer exported as a volume. This caused problems when building on top of the image, since changes in the volume are not persisted between Dockerfile `RUN` instructions. To keep the previous behavior (so that you can mount the volume in another container), create the container with the `-v /app` option.
+
 # Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an

--- a/post-install.sh
+++ b/post-install.sh
@@ -6,6 +6,9 @@ cd $BITNAMI_APP_DIR
 mv conf conf.defaults
 mv htdocs htdocs.defaults
 
+# Create an empty htdocs directory
+mkdir $BITNAMI_APP_DIR/htdocs
+
 # Setup mount point symlinks
 ln -s $BITNAMI_APP_DIR/conf $BITNAMI_APP_VOL_PREFIX/conf
 ln -s $BITNAMI_APP_DIR/logs $BITNAMI_APP_VOL_PREFIX/logs

--- a/rootfs/etc/cont-init.d/01-bitnami-apache
+++ b/rootfs/etc/cont-init.d/01-bitnami-apache
@@ -7,3 +7,5 @@ generate_conf_files
 if [ ! "$(ls -A /app)" ]; then
   cp -r $BITNAMI_APP_DIR/htdocs.defaults/* $BITNAMI_APP_DIR/htdocs
 fi
+
+chown -R $BITNAMI_APP_USER:$BITNAMI_APP_USER $BITNAMI_APP_DIR/htdocs

--- a/test.sh
+++ b/test.sh
@@ -69,7 +69,6 @@ add_vhost() {
   run docker inspect $CONTAINER_NAME
   [[ "$output" =~ "$VOL_PREFIX/logs" ]]
   [[ "$output" =~ "$VOL_PREFIX/conf" ]]
-  [[ "$output" =~ "/app" ]]
 }
 
 @test "Vhosts directory is imported" {


### PR DESCRIPTION
removed `/app` volume from dockerfile

Specifying a volume at `/app` (in the Dockerfile) makes it difficult to
use this image as a base image for derived images. Due to this, we have
removed the `VOLUME` instruction that mounts `/app` as a volume.

The `/app` path continues to function like it did before. As a result if
you want to mount your php application into the container, mount your
application source at `/app` using `-v
/path/on/application/source:/app`.

One advantage of mounting/installing your application at `/app` is that
the image will automatically update the ownership of the
files/directories in `/app` so that it is accessible by the `php-fpm`
process.
