### PR TITLE
Fix permissions on htdocs

### DIFF
--- a/2.4/debian-9/rootfs/libapache.sh
+++ b/2.4/debian-9/rootfs/libapache.sh
@@ -30,6 +30,7 @@ export BITNAMI_DEBUG="${BITNAMI_DEBUG:-false}"
 export APACHE_BASE_DIR="/opt/bitnami/apache"
 export APACHE_BIN_DIR="${APACHE_BASE_DIR}/bin"
 export APACHE_CONF_DIR="${APACHE_BASE_DIR}/conf"
+export APACHE_HTDOCS_DIR="${APACHE_BASE_DIR}/htdocs"
 export APACHE_LOG_DIR="${APACHE_BASE_DIR}/logs"
 export APACHE_TMP_DIR="${APACHE_BASE_DIR}/tmp"
 export APACHE_VHOSTS_DIR="${APACHE_CONF_DIR}/vhosts"
@@ -177,8 +178,8 @@ apache_initialize() {
     # Mount application files
     if ! is_dir_empty "/app"; then
         info "Mounting application files from '/app'..."
-        rm -rf "/opt/bitnami/apache/htdocs"
-        ln -sf "/app" "/opt/bitnami/apache/htdocs"
+        rm -rf "$APACHE_HTDOCS_DIR"
+        ln -sf "/app" "$APACHE_HTDOCS_DIR"
     fi
 
     # Port configuration

--- a/2.4/debian-9/rootfs/postunpack.sh
+++ b/2.4/debian-9/rootfs/postunpack.sh
@@ -84,7 +84,7 @@ eval "$(apache_env)"
 apache_setup_bitnami_config
 
 # Ensure non-root user has write permissions on a set of directories
-for dir in "$APACHE_TMP_DIR" "$APACHE_CONF_DIR" "$APACHE_LOG_DIR" "$APACHE_VHOSTS_DIR" "$APACHE_HTACCESS_DIR"; do
+for dir in "$APACHE_TMP_DIR" "$APACHE_CONF_DIR" "$APACHE_LOG_DIR" "$APACHE_VHOSTS_DIR" "$APACHE_HTACCESS_DIR" "$APACHE_HTDOCS_DIR"; do
     ensure_dir_exists "$dir"
     chmod -R g+rwX "$dir"
 done

--- a/2.4/ol-7/rootfs/libapache.sh
+++ b/2.4/ol-7/rootfs/libapache.sh
@@ -30,6 +30,7 @@ export BITNAMI_DEBUG="${BITNAMI_DEBUG:-false}"
 export APACHE_BASE_DIR="/opt/bitnami/apache"
 export APACHE_BIN_DIR="${APACHE_BASE_DIR}/bin"
 export APACHE_CONF_DIR="${APACHE_BASE_DIR}/conf"
+export APACHE_HTDOCS_DIR="${APACHE_BASE_DIR}/htdocs"
 export APACHE_LOG_DIR="${APACHE_BASE_DIR}/logs"
 export APACHE_TMP_DIR="${APACHE_BASE_DIR}/tmp"
 export APACHE_VHOSTS_DIR="${APACHE_CONF_DIR}/vhosts"
@@ -177,8 +178,8 @@ apache_initialize() {
     # Mount application files
     if ! is_dir_empty "/app"; then
         info "Mounting application files from '/app'..."
-        rm -rf "/opt/bitnami/apache/htdocs"
-        ln -sf "/app" "/opt/bitnami/apache/htdocs"
+        rm -rf "$APACHE_HTDOCS_DIR"
+        ln -sf "/app" "$APACHE_HTDOCS_DIR"
     fi
 
     # Port configuration

--- a/2.4/ol-7/rootfs/postunpack.sh
+++ b/2.4/ol-7/rootfs/postunpack.sh
@@ -84,7 +84,7 @@ eval "$(apache_env)"
 apache_setup_bitnami_config
 
 # Ensure non-root user has write permissions on a set of directories
-for dir in "$APACHE_TMP_DIR" "$APACHE_CONF_DIR" "$APACHE_LOG_DIR" "$APACHE_VHOSTS_DIR" "$APACHE_HTACCESS_DIR"; do
+for dir in "$APACHE_TMP_DIR" "$APACHE_CONF_DIR" "$APACHE_LOG_DIR" "$APACHE_VHOSTS_DIR" "$APACHE_HTACCESS_DIR" "$APACHE_HTDOCS_DIR"; do
     ensure_dir_exists "$dir"
     chmod -R g+rwX "$dir"
 done


### PR DESCRIPTION
**Description of the change**
This PR gives the non-root user permissions on the `htdocs` directory, which are needed to mount a custom application to `/app`

**Applicable issues**
#95 